### PR TITLE
Convert the first argument of :value vectors to keyword

### DIFF
--- a/src/elle_cli/cli.clj
+++ b/src/elle_cli/cli.clj
@@ -47,9 +47,15 @@
   (if (vector? v) (vl v)))
 
 (defn value-reader [key value]
-  (if (or (= key :type) (= key :f))
-    (keyword value)
-      value))
+  (cond
+    (or (= key :type) (= key :f)) (keyword value)
+    ;; e.g. {:value [[:append :x 1] [:r :y nil]]}
+    (and
+      (= key :value)
+      (vector? value)  (not (empty? value))
+      (vector? (first value)) (not (empty? (first value)))
+      (string? (ffirst value)))    (map #(assoc %1 0 (keyword (first %1))) value)
+    :else value))
 
 (defn read-json-history
   "Takes a path to file and loads a history from it, in JSON format."


### PR DESCRIPTION
fixes https://github.com/ligurio/elle-cli/issues/1.

This patch makes `value-reader` convert the first argument of the `:value` vectors to a keyword. For example, with this patch `elle-cli` converts

```json
{"type": "invoke", "process": 0, "value": [["append", "1", 0]], "time": 1644340018839, "index": 0}
```

to

```clojure
{:type "invoke" :process 0 :value [[:append "1" 0]] :time 1644340018839 :index 0}
```
instead of

```clojure
{:type "invoke" :process 0 :value [["append" "1" 0]] :time 1644340018839 :index 0}
```
