### PR TITLE
Use :strict-serializable as a default consistency model

### DIFF
--- a/src/elle_cli/cli.clj
+++ b/src/elle_cli/cli.clj
@@ -95,7 +95,7 @@
    ; Elle-specific options.
    ["-c" "--consistency-models CONSISTENCY-MODELS"
     "(Elle) A collection of consistency models we expect this history to obey."
-    :default [:serializable]]
+    :default [:strict-serializable]]
    ["-a" "--anomalies ANOMALIES"
     "(Elle) A collection of specific anomalies you'd like to look for."
     :default [:G0]]


### PR DESCRIPTION
This patch sets `elle-cli`'s default consistency model to `:strict-serializable` - Elle's default model ([link](https://github.com/jepsen-io/elle/blob/a7a5175969c3b4329e449b18985a0edd84cf035c/src/elle/list_append.clj#L848-L853)).

