### PR TITLE
Fix passing consistency models and anomalies via CLI

### DIFF
--- a/src/elle_cli/cli.clj
+++ b/src/elle_cli/cli.clj
@@ -58,6 +58,9 @@
                   :key-fn keyword
                   :value-fn value-reader))
 
+(defn str->keywords [s]
+  (mapv keyword (str/split s #",")))
+
 (def models
   {"knossos-register"        knossos-model/register
    "knossos-cas-register"    knossos-model/cas-register
@@ -95,10 +98,12 @@
    ; Elle-specific options.
    ["-c" "--consistency-models CONSISTENCY-MODELS"
     "(Elle) A collection of consistency models we expect this history to obey."
-    :default [:strict-serializable]]
+    :default [:strict-serializable]
+    :parse-fn str->keywords]
    ["-a" "--anomalies ANOMALIES"
     "(Elle) A collection of specific anomalies you'd like to look for."
-    :default [:G0]]
+    :default [:G0]
+    :parse-fn str->keywords]
    ["-s" "--cycle-search-timeout CYCLE-SEARCH-TIMEOUT"
     "(Elle) Number of ms for searching a single SCC for a cycle."
     :default 10]


### PR DESCRIPTION
## Description

Fixes #4. Right now it is not possible to specify a list of desired consistency models or anomalies via CLI. This happens because the arguments should be mapped to the expected format - vectors of keywords. This patch implements missing functionality.


## Examples

Without this patch:

```
✗ java -jar target/elle-cli-0.1.0-standalone.jar --model elle-list-append  histories/elle/paper-example.edn  --anomalies G0,G1

java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Iterable (java.lang.String and java.lang.Iterable are in module java.base of loader 'bootstrap')
	at elle.graph$bfs.invokeStatic(graph.clj:270)
	at elle.graph$bfs.invoke(graph.clj:270)
	at elle.consistency_model$all_anomalies_implying.invokeStatic(consistency_model.clj:117)
	at elle.consistency_model$all_anomalies_implying.invoke(consistency_model.clj:112)
	at elle.txn$prohibited_anomaly_types.invokeStatic(txn.clj:279)
	at elle.txn$prohibited_anomaly_types.invoke(txn.clj:269)
	at elle.txn$reportable_anomaly_types.invokeStatic(txn.clj:286)
	at elle.txn$reportable_anomaly_types.invoke(txn.clj:283)
	at elle.txn$additional_graphs.invokeStatic(txn.clj:298)
	at elle.txn$additional_graphs.invoke(txn.clj:289)
	at elle.list_append$check.invokeStatic(list_append.clj:902)
	at elle.list_append$check.invoke(list_append.clj:854)
	at elle_cli.cli$check_history.invokeStatic(cli.clj:155)
	at elle_cli.cli$check_history.invoke(cli.clj:147)
	at elle_cli.cli$_main.invokeStatic(cli.clj:190)
	at elle_cli.cli$_main.doInvoke(cli.clj:168)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at elle_cli.cli.main(Unknown Source)
```

With this patch:

```
✗ java -jar target/elle-cli-0.1.0-standalone.jar --model elle-list-append  histories/elle/paper-example.edn  --anomalies G0,G1
INFO [2022-02-09 15:33:52,633] clojure-agent-send-off-pool-8 - elle.viz Skipping plot of 411 bytes
INFO [2022-02-09 15:33:52,636] clojure-agent-send-off-pool-9 - elle.viz Skipping plot of 603 bytes
```