### PR TITLE
Fix --plot-format CLI argument

### DIFF
--- a/src/elle_cli/cli.clj
+++ b/src/elle_cli/cli.clj
@@ -107,7 +107,8 @@
     :default "store"]
    ["-p" "--plot-format PLOT-FORMAT"
     "(Elle) Either 'png' or 'svg'."
-    :default "svg"]
+    :default :svg
+    :parse-fn keyword]
    ["-t" "--plot-timeout PLOT-TIMEOUT"
     "(Elle) How many milliseconds will we wait to render a SCC plot?"
     :default 10]

--- a/test.sh
+++ b/test.sh
@@ -21,6 +21,7 @@ $ELLE_CLI_BIN $ELLE_CLI_OPT knossos-mutex histories/knossos/mutex/bad/hazelcast.
 
 $ELLE_CLI_BIN $ELLE_CLI_OPT elle-list-append histories/elle/paper-example.edn
 $ELLE_CLI_BIN $ELLE_CLI_OPT elle-list-append histories/elle/paper-example.json
+$ELLE_CLI_BIN $ELLE_CLI_OPT elle-list-append histories/elle/paper-example.json --plot-format svg
 
 $ELLE_CLI_BIN $ELLE_CLI_OPT jepsen-counter histories/jepsen/counter.edn
 $ELLE_CLI_BIN $ELLE_CLI_OPT jepsen-counter histories/jepsen/counter.json


### PR DESCRIPTION
## Description

* Default argument should be a keyword
* Specified argument should be converted to a keyword

Without this patch:

```
✗ lein run --model elle-list-append histories/elle/paper-example.edn

java.util.concurrent.ExecutionException: java.lang.IllegalArgumentException: No matching clause: svg
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
	at clojure.core$deref_future.invokeStatic(core.clj:2304)
	at clojure.core$future_call$reify__8477.deref(core.clj:6976)
	at clojure.core$deref.invokeStatic(core.clj:2324)
	at clojure.core$deref.invoke(core.clj:2310)
	at clojure.core$map$fn__5884.invoke(core.clj:2759)
	at clojure.lang.LazySeq.sval(LazySeq.java:42)
	at clojure.lang.LazySeq.seq(LazySeq.java:58)
	at clojure.lang.RT.seq(RT.java:535)
	at clojure.core$seq__5419.invokeStatic(core.clj:139)
	at clojure.core$dorun.invokeStatic(core.clj:3121)
	at clojure.core$dorun.invoke(core.clj:3121)
	at elle.viz$plot_analysis_BANG_.invokeStatic(viz.clj:206)
	at elle.viz$plot_analysis_BANG_.invoke(viz.clj:189)
	at elle.txn$cycles_BANG_.invokeStatic(txn.clj:515)
	at elle.txn$cycles_BANG_.invoke(txn.clj:496)
	at elle.list_append$check.invokeStatic(list_append.clj:904)
	at elle.list_append$check.invoke(list_append.clj:854)
	at elle_cli.cli$check_history.invokeStatic(cli.clj:155)
	at elle_cli.cli$check_history.invoke(cli.clj:147)
	at elle_cli.cli$_main.invokeStatic(cli.clj:190)
	at elle_cli.cli$_main.doInvoke(cli.clj:168)
	at clojure.lang.RestFn.invoke(RestFn.java:436)
	at clojure.lang.Var.invoke(Var.java:393)
	at user$eval140.invokeStatic(form-init14670889884712696558.clj:1)
	at user$eval140.invoke(form-init14670889884712696558.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:7181)
	at clojure.lang.Compiler.eval(Compiler.java:7171)
	at clojure.lang.Compiler.load(Compiler.java:7640)
	at clojure.lang.Compiler.loadFile(Compiler.java:7578)
	at clojure.main$load_script.invokeStatic(main.clj:475)
	at clojure.main$init_opt.invokeStatic(main.clj:477)
	at clojure.main$init_opt.invoke(main.clj:477)
	at clojure.main$initialize.invokeStatic(main.clj:508)
	at clojure.main$null_opt.invokeStatic(main.clj:542)
	at clojure.main$null_opt.invoke(main.clj:539)
	at clojure.main$main.invokeStatic(main.clj:664)
	at clojure.main$main.doInvoke(main.clj:616)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:705)
	at clojure.main.main(main.java:40)
Caused by: java.lang.IllegalArgumentException: No matching clause: svg
	at elle.viz$save_dot_BANG_.invokeStatic(viz.clj:183)
	at elle.viz$save_dot_BANG_.invoke(viz.clj:177)
	at elle.viz$plot_analysis_BANG_$fn__1344$fn__1348.invoke(viz.clj:215)
	at clojure.core$binding_conveyor_fn$fn__5772.invoke(core.clj:2034)
	at clojure.lang.AFn.call(AFn.java:18)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)

 ✗ lein run --model elle-list-append histories/elle/paper-example.edn --plot-format png
Compiling elle_cli.cli

java.util.concurrent.ExecutionException: java.lang.IllegalArgumentException: No matching clause: png
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
	at clojure.core$deref_future.invokeStatic(core.clj:2304)
	at clojure.core$future_call$reify__8477.deref(core.clj:6976)
	at clojure.core$deref.invokeStatic(core.clj:2324)
	at clojure.core$deref.invoke(core.clj:2310)
	at clojure.core$map$fn__5884.invoke(core.clj:2759)
	at clojure.lang.LazySeq.sval(LazySeq.java:42)
	at clojure.lang.LazySeq.seq(LazySeq.java:58)
	at clojure.lang.RT.seq(RT.java:535)
	at clojure.core$seq__5419.invokeStatic(core.clj:139)
	at clojure.core$dorun.invokeStatic(core.clj:3121)
	at clojure.core$dorun.invoke(core.clj:3121)
	at elle.viz$plot_analysis_BANG_.invokeStatic(viz.clj:206)
	at elle.viz$plot_analysis_BANG_.invoke(viz.clj:189)
	at elle.txn$cycles_BANG_.invokeStatic(txn.clj:515)
	at elle.txn$cycles_BANG_.invoke(txn.clj:496)
	at elle.list_append$check.invokeStatic(list_append.clj:904)
	at elle.list_append$check.invoke(list_append.clj:854)
	at elle_cli.cli$check_history.invokeStatic(cli.clj:155)
	at elle_cli.cli$check_history.invoke(cli.clj:147)
	at elle_cli.cli$_main.invokeStatic(cli.clj:190)
	at elle_cli.cli$_main.doInvoke(cli.clj:168)
	at clojure.lang.RestFn.invoke(RestFn.java:482)
	at clojure.lang.Var.invoke(Var.java:406)
	at user$eval140.invokeStatic(form-init3746590450619792131.clj:1)
	at user$eval140.invoke(form-init3746590450619792131.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:7181)
	at clojure.lang.Compiler.eval(Compiler.java:7171)
	at clojure.lang.Compiler.load(Compiler.java:7640)
	at clojure.lang.Compiler.loadFile(Compiler.java:7578)
	at clojure.main$load_script.invokeStatic(main.clj:475)
	at clojure.main$init_opt.invokeStatic(main.clj:477)
	at clojure.main$init_opt.invoke(main.clj:477)
	at clojure.main$initialize.invokeStatic(main.clj:508)
	at clojure.main$null_opt.invokeStatic(main.clj:542)
	at clojure.main$null_opt.invoke(main.clj:539)
	at clojure.main$main.invokeStatic(main.clj:664)
	at clojure.main$main.doInvoke(main.clj:616)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:705)
	at clojure.main.main(main.java:40)
Caused by: java.lang.IllegalArgumentException: No matching clause: png
	at elle.viz$save_dot_BANG_.invokeStatic(viz.clj:183)
	at elle.viz$save_dot_BANG_.invoke(viz.clj:177)
	at elle.viz$plot_analysis_BANG_$fn__1344$fn__1348.invoke(viz.clj:215)
	at clojure.core$binding_conveyor_fn$fn__5772.invoke(core.clj:2034)
	at clojure.lang.AFn.call(AFn.java:18)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```


With this patch:

```
✗ lein run --model elle-list-append histories/elle/paper-example.edn --plot-format png
INFO [2022-02-09 19:51:00,667] clojure-agent-send-off-pool-8 - elle.viz Timing out visualization of SCC no. 0 containing 3 transactions
INFO [2022-02-09 19:51:00,683] clojure-agent-send-off-pool-2 - elle.viz Timing out visualization of SCC no. 0 containing 2 transactions
INFO [2022-02-09 19:51:00,683] clojure-agent-send-off-pool-6 - elle.viz Timing out visualization of SCC no. 0 containing 3 transactions
histories/elle/paper-example.edn 	 false

 ✗ lein run --model elle-list-append histories/elle/paper-example.edn --plot-format svg
INFO [2022-02-09 19:51:08,191] clojure-agent-send-off-pool-10 - elle.viz Timing out visualization of SCC no. 0 containing 3 transactions
INFO [2022-02-09 19:51:08,206] clojure-agent-send-off-pool-1 - elle.viz Timing out visualization of SCC no. 0 containing 2 transactions
INFO [2022-02-09 19:51:08,206] clojure-agent-send-off-pool-3 - elle.viz Timing out visualization of SCC no. 0 containing 3 transactions
histories/elle/paper-example.edn 	 false
```