### PR TITLE
Make elle-cli defaults consistent with elle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ change log follows the conventions of
 
 ### Changed
 
+- Update default values for CLI arguments so that they are aligned with Elle's.
 - Bump Jepsen version to 0.2.6.
 - Bump Elle version to 0.1.4.
 - Use :strict-serializable as a default consistency model.

--- a/README.md
+++ b/README.md
@@ -83,12 +83,13 @@ An Elle's checker for write-read registers. Options are:
   `G2-item`, `G2-item-process`, `G2-item-realtime`, `G2-process`, `GSIa`,
   `GSIb`, `incompatible-order`, `dirty-update`.
 - **cycle-search-timeout** - how many milliseconds are we willing to search a
-  single SCC for a cycle?
+  single SCC for a cycle? Default value is `1000`.
 - **directory** - where to output files, if desired. Default value is `nil`.
 - **plot-format** - either `png` or `svg`. Default value is `svg`.
 - **plot-timeout** - how many milliseconds will we wait to render a SCC plot?
+  Default value is `5000`.
 - **max-plot-bytes** - maximum size of a cycle graph (in bytes of DOT) which
-  we're willing to try and render.
+  we're willing to try and render. Default value is `65536`.
 
 ### elle-list-append
 
@@ -108,12 +109,13 @@ Options are:
   `G2-item`, `G2-item-process`, `G2-item-realtime`, `G2-process`, `GSIa`,
   `GSIb`, `incompatible-order`, `dirty-update`.
 - **cycle-search-timeout** - how many milliseconds are we willing to search a
-  single SCC for a cycle?
+  single SCC for a cycle? Default value is `1000`.
 - **directory** - where to output files, if desired. Default value is `nil`.
 - **plot-format** - either `png` or `svg`. Default value is `svg`.
 - **plot-timeout** - how many milliseconds will we wait to render a SCC plot?
+  Default value is `5000`.
 - **max-plot-bytes** - maximum size of a cycle graph (in bytes of DOT) which
-  we're willing to try and render.
+  we're willing to try and render. Default value is `65536`.
 
 Example of history:
 

--- a/src/elle_cli/cli.clj
+++ b/src/elle_cli/cli.clj
@@ -112,7 +112,7 @@
     :parse-fn str->keywords]
    ["-s" "--cycle-search-timeout CYCLE-SEARCH-TIMEOUT"
     "(Elle) Number of ms for searching a single SCC for a cycle."
-    :default 10]
+    :default 1000]
    ["-d" "--directory DIRECTORY"
     "(Elle) Where to output files, if desired."
     :default "store"]
@@ -122,10 +122,10 @@
     :parse-fn keyword]
    ["-t" "--plot-timeout PLOT-TIMEOUT"
     "(Elle) How many milliseconds will we wait to render a SCC plot?"
-    :default 10]
+    :default 5000]
    ["-b" "--max-plot-bytes MAX-PLOT-BYTES"
     "(Elle) Maximum size of a cycle graph (in bytes of DOT)."
-    :default 400]
+    :default 65536]
 
    ; Jepsen-specific options.
    ; None.


### PR DESCRIPTION
This patch makes `elle-cli`'s default values aligned with `elle`'s:

* [cycle-search-timeout](https://github.com/jepsen-io/elle/blob/d0105deab770628ab8c6c603427e48370f926aed/src/elle/txn.clj#L343-L345)
* [plot-timeout](https://github.com/jepsen-io/elle/blob/410434bc4b29ab6958af46546aec2c98da83b6f1/src/elle/viz.clj#L209)
* [max-plot-bytes](https://github.com/jepsen-io/elle/blob/410434bc4b29ab6958af46546aec2c98da83b6f1/src/elle/viz.clj#L180)