### PR TITLE
Allow passing empty consistency models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ change log follows the conventions of
 
 ### Changed
 
+- Allow passing an empty consistency model.
 - Update default values for CLI arguments so that they are aligned with Elle's.
 - Bump Jepsen version to 0.2.6.
 - Bump Elle version to 0.1.4.

--- a/src/elle_cli/cli.clj
+++ b/src/elle_cli/cli.clj
@@ -65,7 +65,9 @@
                   :value-fn value-reader))
 
 (defn str->keywords [s]
-  (mapv keyword (str/split s #",")))
+  (if (empty? s)
+    []
+    (mapv keyword (str/split s #","))))
 
 (def models
   {"knossos-register"        knossos-model/register

--- a/test.sh
+++ b/test.sh
@@ -24,6 +24,7 @@ $ELLE_CLI_BIN $ELLE_CLI_OPT elle-rw-register histories/elle/rw-register.json
 $ELLE_CLI_BIN $ELLE_CLI_OPT elle-list-append histories/elle/paper-example.edn
 $ELLE_CLI_BIN $ELLE_CLI_OPT elle-list-append histories/elle/paper-example.json
 $ELLE_CLI_BIN $ELLE_CLI_OPT elle-list-append histories/elle/paper-example.json --plot-format svg
+$ELLE_CLI_BIN $ELLE_CLI_OPT elle-list-append histories/elle/paper-example.json --anomalies G-single-process --consistency-models ''
 
 $ELLE_CLI_BIN $ELLE_CLI_OPT jepsen-counter histories/jepsen/counter.edn
 $ELLE_CLI_BIN $ELLE_CLI_OPT jepsen-counter histories/jepsen/counter.json


### PR DESCRIPTION
## Description

Right now it is not possible to pass an empty list of consistency models to `elle-cli`. One might want to do that if they want to check only for specific anomalies, for example:

```
 java -jar target/elle-cli-0.1.0-standalone.jar --model elle-list-append history.json --format json --anomalies G-single-process --consistency-models ''
```

For completeness, one might want to do that _in principle_ because Elle does not map yet all known consistency models to anomalies. The right side of the [Consistency Models](https://jepsen.io/consistency) hierarchy is still missing.

Right the command above fails with:

```
java.lang.IllegalArgumentException: Unknown consistency model (:); known models are:
#{:1SR :PL-1 :PL-2 :PL-2+ :PL-2.99 :PL-2L :PL-3 :PL-3U :PL-CS :PL-FCV :PL-MSR :PL-SI :PL-SS :PRAM :ROLA :causal :causal-cerone :conflict-serializable :consistent-view :cursor-stability :forward-consistent-view :linearizable :monotonic-atomic-view :monotonic-reads :monotonic-snapshot-read :monotonic-view :monotonic-writes :parallel-snapshot-isolation :prefix :read-atomic :read-committed :read-uncommitted :read-your-writes :repeatable-read :sequential :serializable :session-serializable :snapshot-isolation :strict-serializable :strong-serializable :strong-session-serializable :strong-session-snapshot-isolation :strong-snapshot-isolation :update-serializable :view-serializable :writes-follow-reads}
	at elle.consistency_model$validate_models.invokeStatic(consistency_model.clj:261)
	at elle.consistency_model$validate_models.invoke(consistency_model.clj:256)
	at elle.consistency_model$all_implied_models.invokeStatic(consistency_model.clj:270)
	at elle.consistency_model$all_implied_models.invoke(consistency_model.clj:266)
	at elle.consistency_model$anomalies_prohibited_by.invokeStatic(consistency_model.clj:386)
	at elle.consistency_model$anomalies_prohibited_by.invoke(consistency_model.clj:377)
	at elle.txn$prohibited_anomaly_types.invokeStatic(txn.clj:280)
	at elle.txn$prohibited_anomaly_types.invoke(txn.clj:269)
	at elle.txn$reportable_anomaly_types.invokeStatic(txn.clj:286)
	at elle.txn$reportable_anomaly_types.invoke(txn.clj:283)
	at elle.txn$additional_graphs.invokeStatic(txn.clj:298)
	at elle.txn$additional_graphs.invoke(txn.clj:289)
	at elle.list_append$check.invokeStatic(list_append.clj:896)
	at elle.list_append$check.invoke(list_append.clj:848)
	at elle_cli.cli$check_history.invokeStatic(cli.clj:167)
	at elle_cli.cli$check_history.invoke(cli.clj:159)
	at elle_cli.cli$_main.invokeStatic(cli.clj:202)
	at elle_cli.cli$_main.doInvoke(cli.clj:180)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at elle_cli.cli.main(Unknown Source)
```

This patch fixes described bug.

I hope I am not bothering you too much with an avalanche of PRs :)