### PR TITLE
Fix default value for --directory CLI argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ change log follows the conventions of
 ### Fixed
 
 - Fix --cycle-search-timeout, --plot-timeout, and --max-plot-bytes CLI arguments
+- Fix default value for --directory CLI argument
 
 ### Changed
 

--- a/src/elle_cli/cli.clj
+++ b/src/elle_cli/cli.clj
@@ -118,7 +118,7 @@
     :parse-fn #(Integer/parseInt %)]
    ["-d" "--directory DIRECTORY"
     "(Elle) Where to output files, if desired."
-    :default "store"]
+    :default nil]
    ["-p" "--plot-format PLOT-FORMAT"
     "(Elle) Either 'png' or 'svg'."
     :default :svg


### PR DESCRIPTION
This patch fixes default value for `--directory` CLI argument. README specifies that it should be `nil` which is consistent with Elle. However, right now it is set to `store` in the code.