### PR TITLE
Just a build test (Java headless)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,8 +59,6 @@ jobs:
     - name: Run regression tests on Ubuntu
       run: /usr/bin/xvfb-run bash -x ./test.sh
       if: ${{ matrix.operating-system == 'ubuntu-latest' }}
-      env:
-        DISPLAY: :99.0
 
     - name: Run regression tests on macOS
       run: bash -x ./test.sh

--- a/src/elle_cli/cli.clj
+++ b/src/elle_cli/cli.clj
@@ -202,6 +202,7 @@
 
 (defn -main
   [& args]
+  (println "HEADLESS? " (System/getProperty "java.awt.headless"))
   (try
     (let [{:keys [options arguments summary errors]} (cli/parse-opts args opts)
           model-name (:model options)

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@
 set -eu
 
 ELLE_CLI_VERSION="0.1.3"
-ELLE_CLI_BIN="java -jar target/elle-cli-${ELLE_CLI_VERSION}-standalone.jar"
+ELLE_CLI_BIN="java -Djava.awt.headless=true -jar target/elle-cli-${ELLE_CLI_VERSION}-standalone.jar"
 ELLE_CLI_OPT="--model"
 
 $ELLE_CLI_BIN $ELLE_CLI_OPT cas-register histories/knossos/cas-register/bad/bad-analysis.edn


### PR DESCRIPTION
1st commit: confirm there's no need to set a display when the application is launched in headless mode (confirmed, test passes on ubuntu)

2nd commit: shows that when packaging with `lein uberjar` the `:jvm-opts` is lost.
i.e. the uberjar is not running in headless mode, despite the headless mode property being set in`project.clj`