### PR TITLE
Bump Jepsen version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,5 +14,5 @@
                  [org.clojure/data.json "2.4.0"]
                  [spootnik/unilog "0.7.28"] ; required by elle
                  [elle "0.1.5"]
-                 [jepsen "0.2.6"]
+                 [jepsen "0.2.7"]
                  [knossos "0.3.8"]])


### PR DESCRIPTION
Version of Jepsen has been updated to 0.2.7,
see changes in [1] and [2].

1. https://github.com/jepsen-io/jepsen/compare/v0.2.6...v0.2.7
2. https://github.com/jepsen-io/jepsen/releases/tag/v0.2.7