### PR TITLE
Knossos register is gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ change log follows the conventions of
 
 ### Changed
 
+- Knossos register model is removed. Use Elle's register instead. (#42).
+
 ## [0.1.4] - 2022-06-30
 
 [0.1.4]: https://github.com/ligurio/elle-cli/compare/0.1.3...0.1.4

--- a/src/elle_cli/cli.clj
+++ b/src/elle_cli/cli.clj
@@ -73,10 +73,8 @@
     (mapv keyword (str/split s #","))))
 
 (def models
-  {"knossos-register"        knossos-model/register
-   "knossos-cas-register"    knossos-model/cas-register
+  {"knossos-cas-register"    knossos-model/cas-register
    "knossos-mutex"           knossos-model/mutex
-   "register"                knossos-model/register
    "cas-register"            knossos-model/cas-register
    "mutex"                   knossos-model/mutex
    "jepsen-bank"             jepsen-bank/checker
@@ -185,10 +183,8 @@
     (case model-name
        ; Operations in a histories passed to a Knossos additionally normalized,
        ; see src/knossos/cli.clj:read-history.
-       "register" (competition/analysis (checker-fn) (history/parse-ops history))
        "cas-register" (competition/analysis (checker-fn) (history/parse-ops history))
        "mutex" (competition/analysis (checker-fn) (history/parse-ops history))
-       "knossos-register" (competition/analysis (checker-fn) (history/parse-ops history))
        "knossos-cas-register" (competition/analysis (checker-fn) (history/parse-ops history))
        "knossos-mutex" (competition/analysis (checker-fn) (history/parse-ops history))
        "comments" ((independent/checker (checker-fn)) (history/parse-ops history))


### PR DESCRIPTION
Commit 4e55c2e ("Remove model register in documentation") removed knossos register model in documentation. This commit finally removes model itself. Use elle's register instead.

Closes #42