### PR TITLE
Bump Jepsen version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,5 +14,5 @@
                  [org.clojure/data.json "2.4.0"]
                  [spootnik/unilog "0.7.28"] ; required by elle
                  [elle "0.1.7"]
-                 [jepsen "0.3.3"]
+                 [jepsen "0.3.4"]
                  [knossos "0.3.9"]])


### PR DESCRIPTION
Jepsen [1] has been updated.

1. https://github.com/jepsen-io/jepsen/releases/tag/v0.3.4