### PR TITLE
Bump Jepsen version to 0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ change log follows the conventions of
 ### Changed
 
 - Bump Elle version to 0.2.1.
-- Bump Jepsen version to 0.3.4.
+- Bump Jepsen version to 0.3.7.
 
 ## [0.1.7]
 

--- a/project.clj
+++ b/project.clj
@@ -14,5 +14,5 @@
                  [org.clojure/data.json "2.4.0"]
                  [spootnik/unilog "0.7.28"] ; required by elle
                  [elle "0.2.1"]
-                 [jepsen "0.3.4"]
+                 [jepsen "0.3.7"]
                  [knossos "0.3.9"]])


### PR DESCRIPTION
Jepsen has been updated to version v0.3.7.
See changelog [1] and separate changelogs for 0.3.5 [2], 0.3.6 [3] and 0.3.7 [4].

1. https://github.com/jepsen-io/jepsen/compare/v0.3.4...v0.3.7
2. https://github.com/jepsen-io/jepsen/releases/tag/v0.3.5
3. https://github.com/jepsen-io/jepsen/releases/tag/v0.3.6
4. https://github.com/jepsen-io/jepsen/releases/tag/v0.3.7