### PR TITLE
Fix a set checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ change log follows the conventions of
 
 ### Fixed
 
+- A `set` checker (#44).
+
 ### Changed
 
 - Bump Elle version to 0.2.1.

--- a/README.md
+++ b/README.md
@@ -272,8 +272,11 @@ A Jepsen's checker for a set histories.
 Given a set of `:add` operations, that inserts a sequence of unique records
 into a table, followed by a final `:read`, that concurrently attempts to read
 all of those records back, verifies that every successfully added element is
-present in the read, and that the read contains only elements for which an add
-was attempted.
+present in the read, and that the read contains only elements for which an `:add`
+was attempted. We measure how long it takes for a record to become
+durably visible, or, if it lost, how long it takes to disappear.
+A linearizable `set` should make every inserted element
+immediately visible.
 
 Example of history:
 

--- a/histories/jepsen/set.edn
+++ b/histories/jepsen/set.edn
@@ -1,0 +1,8 @@
+[{:type :invoke,:f :add, :value 0, :process 0, :time 10529279413, :index 0},
+{:type :ok,     :f :add, :value 0, :process 0, :time 10661777878, :index 1},
+{:type :invoke, :f :add, :value 1, :process 0, :time 10761664977, :index 2},
+{:type :ok,     :f :add, :value 1, :process 0, :time 10888511828, :index 3},
+{:type :invoke, :f :add, :value 2, :process 0, :time 11077906807, :index 4},
+{:type :ok,     :f :add, :value 2, :process 0, :time 11209256522, :index 5},
+{:type :invoke, :f :read, :value nil, :process 0, :time 11209256522, :index 6},
+{:type :ok, :f :read, :value [0 1 2], :process 0, :time 84944594608, :index 7}]

--- a/src/elle_cli/cli.clj
+++ b/src/elle_cli/cli.clj
@@ -196,6 +196,7 @@
        "elle-rw-register" (checker-fn options history)
        "bank" (jepsen-model/check-safe (checker-fn {:negative-balances? true}) nil history)
        "counter" (jepsen-model/check-safe (checker-fn) nil history)
+       "set" (jepsen-model/check-safe (checker-fn) nil history)
        "set-full" (jepsen-model/check-safe (checker-fn) nil history)
        "jepsen-bank" (jepsen-model/check-safe (checker-fn {:negative-balances? true}) nil history)
        "jepsen-counter" (jepsen-model/check-safe (checker-fn) nil history)

--- a/test.sh
+++ b/test.sh
@@ -55,6 +55,7 @@ run_test 0 "--model counter histories/jepsen/counter.json"
 
 run_test 1 "--model set-full histories/jepsen/set_full.edn"
 run_test 1 "--model set-full histories/jepsen/set_full.json"
+run_test 0 "--model set      histories/jepsen/set.edn"
 
 run_test 1 "--model bank histories/jepsen/bank.edn"
 run_test 1 "--model bank histories/jepsen/bank.json"


### PR DESCRIPTION
```
$ java -jar ~/sources/elle-cli/target/elle-cli-0.1.7-standalone.jar --verbose --model set histories/jepsen/set.edn 
{"ok-count":3,
 "valid?":true,
 "lost-count":0,
 "lost":"#{}",
 "acknowledged-count":3,
 "recovered":"#{}",
 "ok":"#{0..2}",
 "attempt-count":3,
 "unexpected":"#{}",
 "unexpected-count":0,
 "recovered-count":0}
```

Fixes #44