### PR TITLE
Getting rid of deprecated models names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ change log follows the conventions of
 - Bump Elle version to 0.2.1.
 - Bump Jepsen version to 0.3.7.
 
+### Removed
+
+- Model names with prefixes `jepsen-` and `knossos-`.
+
 ## [0.1.7]
 
 [0.1.7]: https://github.com/ligurio/elle-cli/compare/0.1.6...0.1.7

--- a/src/elle_cli/cli.clj
+++ b/src/elle_cli/cli.clj
@@ -74,15 +74,8 @@
     (mapv keyword (str/split s #","))))
 
 (def models
-  {"knossos-cas-register"    knossos-model/cas-register
-   "knossos-mutex"           knossos-model/mutex
-   "cas-register"            knossos-model/cas-register
+  {"cas-register"            knossos-model/cas-register
    "mutex"                   knossos-model/mutex
-   "jepsen-bank"             jepsen-bank/checker
-   "jepsen-long-fork"        jepsen-long-fork/checker
-   "jepsen-counter"          jepsen-model/counter
-   "jepsen-set"              jepsen-model/set
-   "jepsen-set-full"         jepsen-model/set-full
    "bank"                    jepsen-bank/checker
    "long-fork"               jepsen-long-fork/checker
    "counter"                 jepsen-model/counter
@@ -90,8 +83,6 @@
    "set-full"                jepsen-model/set-full
    "comments"                comments-model/checker
    "sequential"              sequential-model/checker
-   "elle-rw-register"        elle-rw-register/check
-   "elle-list-append"        elle-list-append/check
    "rw-register"             elle-rw-register/check
    "list-append"             elle-list-append/check})
 


### PR DESCRIPTION
The commit 729ab5735bf7
("Add models with names wo checker name in prefix") deprecated model names with prefixes `jepsen-` and `knossos-`. Model names without prefixes were introduced:

- `elle-rw-register` -> `rw-register`
- `elle-list-append` -> `list-append`
- `jepsen-bank` -> `bank`
- `jepsen-counter` -> `counter`
- `jepsen-set` -> `set`
- `jepsen-set-full` -> `set-full`
- `jepsen-long-fork` -> `long-fork`
- `knossos-register` -> `rw-register`
- `knossos-cas-register` -> `cas-register`
- `knossos-mutex` -> `mutex`

The following model names have been removed: `elle-rw-register`, `elle-list-append`, `jepsen-bank`, `jepsen-counter`, `jepsen-set`, `jepsen-set-full`, `jepsen-long-fork`, `knossos-register`, `knossos-cas-register`, `knossos-mutex`.

Follows up #38