### PR TITLE
Print unknown status without colon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ change log follows the conventions of
 - Bump Jepsen version to 0.3.10.
 - Bump Knossos version to 0.3.13 (0.1.13).
 - Bump Elle version to 0.2.5.
+- Print unknown status without colon (#2).
 
 [Unreleased]: https://github.com/ligurio/elle-cli/compare/0.1.9...HEAD
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ three validity states:
 
 - `true`      means the history was valid
 - `false`     means the history was invalid
-- `:unknown`  means checker was unable to complete the analysis; e.g. it ran
+- `unknown`   means checker was unable to complete the analysis; e.g. it ran
               out of memory.
 
 In some cases conversion of history from JSON format to Clojure data structures

--- a/src/elle_cli/cli.clj
+++ b/src/elle_cli/cli.clj
@@ -228,7 +228,8 @@
         (let [read-history  (or read-history (read-fn-by-extension filepath))
               history       (h/history (read-history filepath))
               analysis      (check-history model-name history options)
-              validness     (:valid? analysis)]
+              validness     (:valid? analysis)
+              validness     (if (keyword? validness) (name validness) validness)]
 
         (swap! results assoc filepath validness)
 


### PR DESCRIPTION
The status `:unknown` means to checker was unable to complete the analysis; e.g. it ran out of memory. `elle-cli` prints it as a Clojure keyword (with colon), the patch changes this and `elle-cli` print it without colon.


Closes #2