### PR TITLE
Bump Elle version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ change log follows the conventions of
 
 - Bump Jepsen version to 0.3.11.
 - Bump Knossos version to 0.3.15.
-- Bump Elle version to 0.2.6.
+- Bump Elle version to 0.2.7.
 - Print unknown status without colon (#2).
 
 ### Fixed

--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,6 @@
                  [org.clojure/tools.logging "1.1.0"]
                  [org.clojure/data.json "2.4.0"]
                  [spootnik/unilog "0.7.28"] ; required by elle
-                 [elle "0.2.6"]
+                 [elle "0.2.7"]
                  [jepsen "0.3.11"]
                  [knossos "0.3.15"]])


### PR DESCRIPTION
Elle has been updated to version v0.2.7. See changes in [1].

https://github.com/jepsen-io/elle/compare/v0.2.6...v0.2.7