### PR TITLE
Add option --output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,20 @@ change log follows the conventions of
 
 ## [Unreleased]
 
+### Added
+
+- An option `--output` that accepts `text` or `json`. Default is `text`.
+
 ### Changed
 
 - Bump Jepsen version to 0.3.11.
 - Bump Knossos version to 0.3.15.
 - Bump Elle version to 0.2.7.
 - Print unknown status without colon (#2).
+
+### Deprecated
+
+- An option `--verbose` is deprecated in favor of `--output json`.
 
 ### Fixed
 

--- a/src/elle_cli/cli.clj
+++ b/src/elle_cli/cli.clj
@@ -103,8 +103,11 @@
     :parse-fn history-read-fn
     :validate [identity
                (str "Must be one of " (str/join ", " (sort (keys history-read-fn))))]]
-   ["-v" "--verbose"
-    "(General) Enable verbose mode."]
+   ["-v" "--output OUTPUT"
+    "(General) Output format. Either 'text' or 'json'. Defaults to 'text'."
+    :default :text
+    :parse-fn keyword
+    :validate [#{:text :json} "Must be one of text, json"]]
    ["-h" "--help"
     "(General) Print usage."]
 
@@ -218,7 +221,8 @@
 (defn -main
   [& args]
   (try
-    (let [{:keys [options arguments summary errors]} (cli/parse-opts args opts)
+    (let [args (mapv #(if (= "--verbose" %) "--output json" %) args)
+          {:keys [options arguments summary errors]} (cli/parse-opts args opts)
           model-name (:model options)
           read-history (:format options)
           results (atom (hash-map))
@@ -244,7 +248,7 @@
 
         (swap! results assoc filepath validness)
 
-        (if (true? (:verbose options))
+        (if (= :json (:output options))
           (json/pprint analysis)
           (println filepath "\t" validness))))
 


### PR DESCRIPTION
The patch adds an option `--output` that accepts `text` or `json`. Default is `text`. When `--output text` is used, a short summary is printed. When `--output json` is used, the full analysis is printed as JSON. An option `--verbose` is deprecated in favor of `--output json`.